### PR TITLE
Add methods to convert to and from networkx graphs

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,7 @@ Added
 ~~~~~
 * `Issue #3 <https://github.com/pmacg/py-sgtl/issues/3>`_ - add ``total_volume`` method to ``sgtl.graph.Graph``
 * `Issue #2 <https://github.com/pmacg/py-sgtl/issues/2>`_ - add ``_check_vert_num`` method to ``sgtl.graph.Graph``
+* `Issue #9 <https://github.com/pmacg/py-sgtl/issues/9>`_ - add methods for converting to and from ``networkx`` graph objects.
 
 Fixed
 ~~~~~

--- a/docs/source/generated/sgtl.graph.Graph.rst
+++ b/docs/source/generated/sgtl.graph.Graph.rst
@@ -20,6 +20,8 @@ sgtl.graph.Graph
       ~Graph.bipartiteness
       ~Graph.conductance
       ~Graph.degree_matrix
+      ~Graph.draw
+      ~Graph.from_networkx
       ~Graph.inverse_degree_matrix
       ~Graph.inverse_sqrt_degree_matrix
       ~Graph.laplacian_matrix
@@ -27,6 +29,7 @@ sgtl.graph.Graph
       ~Graph.number_of_edges
       ~Graph.number_of_vertices
       ~Graph.random_walk_laplacian_matrix
+      ~Graph.to_networkx
       ~Graph.total_volume
       ~Graph.volume
       ~Graph.weight

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ furo
 numpy
 pylint
 networkx
+matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytest
 furo
 numpy
 pylint
+networkx

--- a/sgtl/graph.py
+++ b/sgtl/graph.py
@@ -7,6 +7,7 @@ from typing import List
 import scipy
 import scipy.sparse
 import numpy as np
+import networkx as nx
 
 
 class Graph:
@@ -43,6 +44,34 @@ class Graph:
         self.inv_degrees = list(map(lambda x: 1 / x if x != 0 else 0, self.degrees))
         self.sqrt_degrees = list(map(math.sqrt, self.degrees))
         self.inv_sqrt_degrees = list(map(lambda x: 1 / x if x > 0 else 0, self.sqrt_degrees))
+
+    @staticmethod
+    def from_networkx(netx_graph: nx.Graph, edge_weight_attribute='weight'):
+        """
+        Given a networkx graph object, convert it to an SGTL graph object. Unless otherwise specified, this method
+        will use the 'weight' attribute on the networkx edges to assign the weight of the edges. If no such attribute
+        is present, the edges will be added with weight 1.
+
+        :param netx_graph: The networkx graph object to be converted.
+        :param edge_weight_attribute: (default 'weight') the edge attribute to be used to generate the edge weights.
+        :return: An SGTL graph which is equivalent to the given networkx graph.
+        """
+        return Graph(nx.adjacency_matrix(netx_graph, weight=edge_weight_attribute))
+
+    def to_networkx(self) -> nx.Graph:
+        """
+        Construct a networkx graph which is equivalent to this SGTL graph.
+        """
+        return nx.Graph(self.adj_mat)
+
+    def draw(self):
+        """
+        Plot the graph, by first converting to a networkx graph. This will use the default networkx plotting
+        functionality. If you'd like to do something more fancy, then you should convert the graph to a networkx graph
+        using the ``to_networkx`` method and use networkx directly.
+        """
+        nx_graph = self.to_networkx()
+        nx.draw(nx_graph)
 
     def number_of_vertices(self) -> int:
         """The number of vertices in the graph."""

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -272,7 +272,7 @@ def test_float_weights():
 def test_networkx():
     # Test the methods for converting from and to networkx graphs.
     # Start by constructing a networkx graph
-    netx_graph = networkx.generators.barbell_graph(4, 2)
+    netx_graph = networkx.generators.barbell_graph(4, 1)
     graph = sgtl.Graph.from_networkx(netx_graph)
 
     assert graph.number_of_vertices() == 9
@@ -281,12 +281,12 @@ def test_networkx():
     expected_adjacency_matrix = sp.sparse.csr_matrix([[0, 1, 1, 1, 0, 0, 0, 0, 0],
                                                       [1, 0, 1, 1, 0, 0, 0, 0, 0],
                                                       [1, 1, 0, 1, 0, 0, 0, 0, 0],
-                                                      [1, 1, 1, 0, 1, 0, 0, 0, 0],
-                                                      [0, 0, 0, 1, 0, 1, 0, 0, 0],
-                                                      [0, 0, 0, 0, 1, 0, 1, 1, 1],
-                                                      [0, 0, 0, 0, 0, 1, 0, 1, 1],
-                                                      [0, 0, 0, 0, 0, 1, 1, 0, 1],
-                                                      [0, 0, 0, 0, 0, 1, 1, 1, 0]])
+                                                      [1, 1, 1, 0, 0, 0, 0, 0, 1],
+                                                      [0, 0, 0, 0, 0, 1, 1, 1, 1],
+                                                      [0, 0, 0, 0, 1, 0, 1, 1, 0],
+                                                      [0, 0, 0, 0, 1, 1, 0, 1, 0],
+                                                      [0, 0, 0, 0, 1, 1, 1, 0, 0],
+                                                      [0, 0, 0, 1, 1, 0, 0, 0, 0]])
     adj_mat_diff = (graph.adj_mat - expected_adjacency_matrix)
     adj_mat_diff.eliminate_zeros()
     assert adj_mat_diff.nnz == 0
@@ -299,7 +299,7 @@ def test_networkx():
     assert netx_graph.number_of_nodes() == 9
     assert netx_graph.number_of_edges() == 14
     assert netx_graph.has_edge(0, 1)
-    assert netx_graph.has_edge(3, 4)
-    assert netx_graph.has_edge(4, 5)
-    assert not netx_graph.has_edge(2, 4)
+    assert netx_graph.has_edge(3, 8)
+    assert netx_graph.has_edge(8, 4)
+    assert not netx_graph.has_edge(2, 8)
 


### PR DESCRIPTION
Add the `from_networkx` and `to_networkx` methods to the `sgtl.Graph` object. Closes #9 .